### PR TITLE
Fetch Quandl financial data (closes #48)

### DIFF
--- a/public/.eslintrc
+++ b/public/.eslintrc
@@ -1,6 +1,7 @@
 {
     "globals": {
         "angular": true,
+        "moment":  true,
         "fin": true,
         "window": true
     }

--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.8/angular.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.8/angular-route.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.8/angular-resource.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
     <script src="app.js"></script>
     <script src="thumbnails-controller.js"></script>
     <script src="search-controller.js"></script>

--- a/public/quandl-service.js
+++ b/public/quandl-service.js
@@ -3,8 +3,63 @@
 
     angular.module('openfin.quandl', ['ngResource'])
         .factory('quandlService', ['$resource', function($resource) {
-            return $resource('https://www.quandl.com/api/v3/datasets.json?api_key=kM9Z9aEULVDD7svZ4A8B&query=:query&database_code=WIKI', {}, {
-                get: { method: 'GET', cache: true }
-            });
+            var apiKey = 'api_key=kM9Z9aEULVDD7svZ4A8B';
+
+            function stock() {
+                return $resource('https://www.quandl.com/api/v3/datasets.json?' + apiKey + '&query=:query&database_code=WIKI', {}, {
+                    get: { method: 'GET', cache: true }
+                });
+            }
+
+            function stockData() {
+                var startDate = moment().subtract(1, 'weeks').format('YYYY-MM-DD'),
+                    json;
+
+                return $resource('https://www.quandl.com/api/v3/datasets/WIKI/:code/data.json?' + apiKey + '&start_date=' + startDate, {}, {
+                    get: {
+                        method: 'GET',
+                        transformResponse: function(data, headers) {
+                            json = angular.fromJson(data);
+                            processResponse(json);
+                            return json;
+                        },
+                        cache: true
+                    }
+                });
+            }
+
+            function processResponse(json) {
+                var datasetData = json.dataset_data,
+                    financialData = datasetData.data,
+                    results = [],
+                    i = 0,
+                    max = financialData.length;
+
+                for (i; i < max; i++) {
+                    results.push(extract(financialData[i]));
+                }
+
+                json.stockData = {
+                    startDate: datasetData.start_date,
+                    endDate: datasetData.end_date,
+                    data: results
+                };
+            }
+
+            function extract(data) {
+                return {
+                    date: data[0],
+                    open: data[1],
+                    high: data[2],
+                    low: data[3],
+                    close: data[4],
+                    volume: data[5]
+                };
+            }
+
+            return {
+                stock: stock,
+                stockData: stockData
+            };
         }]);
 }());

--- a/public/quandl-service.js
+++ b/public/quandl-service.js
@@ -3,10 +3,16 @@
 
     angular.module('openfin.quandl', ['ngResource'])
         .factory('quandlService', ['$resource', function($resource) {
-            var apiKey = 'api_key=kM9Z9aEULVDD7svZ4A8B';
+            var API_KEY = 'api_key=kM9Z9aEULVDD7svZ4A8B',
+                DATE_INDEX = 0,
+                OPEN_INDEX = 1,
+                HIGH_INDEX = 2,
+                LOW_INDEX = 3,
+                CLOSE_INDEX = 4,
+                VOLUME_INDEX = 5;
 
             function stock() {
-                return $resource('https://www.quandl.com/api/v3/datasets.json?' + apiKey + '&query=:query&database_code=WIKI', {}, {
+                return $resource('https://www.quandl.com/api/v3/datasets.json?' + API_KEY + '&query=:query&database_code=WIKI', {}, {
                     get: { method: 'GET', cache: true }
                 });
             }
@@ -15,7 +21,7 @@
                 var startDate = moment().subtract(1, 'weeks').format('YYYY-MM-DD'),
                     json;
 
-                return $resource('https://www.quandl.com/api/v3/datasets/WIKI/:code/data.json?' + apiKey + '&start_date=' + startDate, {}, {
+                return $resource('https://www.quandl.com/api/v3/datasets/WIKI/:code/data.json?' + API_KEY + '&start_date=' + startDate, {}, {
                     get: {
                         method: 'GET',
                         transformResponse: function(data, headers) {
@@ -48,12 +54,12 @@
 
             function extract(data) {
                 return {
-                    date: data[0],
-                    open: data[1],
-                    high: data[2],
-                    low: data[3],
-                    close: data[4],
-                    volume: data[5]
+                    date: data[DATE_INDEX],
+                    open: data[OPEN_INDEX],
+                    high: data[HIGH_INDEX],
+                    low: data[LOW_INDEX],
+                    close: data[CLOSE_INDEX],
+                    volume: data[VOLUME_INDEX]
                 };
             }
 

--- a/public/search-controller.js
+++ b/public/search-controller.js
@@ -14,7 +14,7 @@
                 self.submit = function() {
                     $location.path('/search/' + self.query);
 
-                    quandlService.get({ query: self.query }, function(result) {
+                    quandlService.stock().get({ query: self.query }, function(result) {
                         // When the result has been fetched it will have been cached.
                         $location.path('/stock/' + self.query);
                     });

--- a/public/stock-controller.js
+++ b/public/stock-controller.js
@@ -4,12 +4,39 @@
     angular.module('openfin.stock', ['openfin.quandl'])
        .controller('StockCtrl', ['$routeParams', 'quandlService', function($routeParams, quandlService) {
            var self = this;
+           self.stocks = [];
 
-           self.results = '';
-
-           quandlService.get({ query: $routeParams.query }, function(result) {
+           quandlService.stock().get({ query: $routeParams.query }, function(result) {
                // Re-fetch the cached result.
-               self.results = result.datasets;
+               var fetchedStocks = result.datasets,
+                   length = fetchedStocks.length,
+                   i,
+                   fetchedStock,
+                   stock;
+
+               for (i = 0; i < length; i++) {
+                   fetchedStock = fetchedStocks[i];
+                   self.stocks.push({
+                       name: fetchedStock.name,
+                       code: fetchedStock.dataset_code
+                   });
+               }
+
+               // After the stock meta-data has been fetched and displayed the financial data
+               // can be retrieved and displayed
+               for (i = 0; i < length; i++) {
+                   stock = self.stocks[i];
+                   fetchStockData(stock);
+               }
            });
+
+           function fetchStockData(stock) {
+               quandlService.stockData().get({ code: stock.code }, function(result) {
+                   var data = result.stockData;
+                   stock.data = data.data;
+                   stock.startDate = data.startDate;
+                   stock.endDate = data.endDate;
+               });
+           }
        }]);
 }());

--- a/public/stockData.html
+++ b/public/stockData.html
@@ -1,5 +1,12 @@
 ﻿<div class="container-fluid">
     <ul>
-        <li ng-repeat="stock in stockCtrl.results">Name: {{stock.name}}, Code: {{stock.dataset_code}}</li>
+        <li ng-repeat="stock in stockCtrl.stocks">
+            Name: {{stock.name}}, Code: {{stock.code}}, Start Date: {{stock.startDate}}, End Date: {{stock.endDate}}
+            <ul>
+                <li ng-repeat="stockData in stock.data">
+                    Date: {{stockData.date}}, Open: {{stockData.open}}
+                </li>
+            </ul>
+        </li>
     </ul>
 </div>


### PR DESCRIPTION
Fetches financial data. Note the UI has not been designed, so I've included a skeleton just to show that data is being received, asynchronously.

As discussed first all the search results for the query are populated, and when they are all fetched the extra data for them all is then requested and displayed.