### PR TITLE
Save list of searched stocks (part 1)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,10 +43,12 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.8/angular-route.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.8/angular-resource.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
+    <script src="https://cdn.rawgit.com/auth0/angular-storage/master/dist/angular-storage.js"></script>
     <script src="app.js"></script>
     <script src="thumbnails-controller.js"></script>
     <script src="search-controller.js"></script>
     <script src="stock-controller.js"></script>
+    <script src="store-service.js"></script>
     <script src="quandl-service.js"></script>
 </body>
 </html>

--- a/public/store-service.js
+++ b/public/store-service.js
@@ -1,0 +1,53 @@
+(function() {
+    'use strict';
+
+    angular.module('openfin.store', ['angular-storage'])
+        .factory('storeService', ['store', function(store) {
+            var initialStocks = {
+                'AAPL': 0,
+                'MSFT': 0,
+                'TITN': 0,
+                'SNDK': 0,
+                'TSLA': 0
+            };
+
+            var mostVisitedStocks = store.get('stocks') || initialStocks;
+
+            function order(obj) {
+                var tuples = [];
+
+                for (var key in obj) {
+                    if (obj.hasOwnProperty(key)) {
+                        tuples.push([key, obj[key]]);
+                    }
+                }
+
+                tuples = tuples.sort(function(a, b) {
+                    return b[1] - a[1];
+                });
+
+                return tuples.map(function(x) {
+                    return x[0];
+                });
+            }
+
+            function get() {
+                return order(mostVisitedStocks);
+            }
+
+            function increment(stockName) {
+                if (mostVisitedStocks[stockName] !== undefined) {
+                    mostVisitedStocks[stockName]++;
+                } else {
+                    mostVisitedStocks[stockName] = 1;
+                }
+
+                store.set('stocks', mostVisitedStocks);
+            }
+
+            return {
+                getStocks: get,
+                incrementStock: increment
+            };
+        }]);
+}());

--- a/public/thumbnails-controller.js
+++ b/public/thumbnails-controller.js
@@ -1,20 +1,17 @@
 (function() {
     'use strict';
 
-    angular.module('openfin.thumbnails', [])
-        .controller('ThumbnailsCtrl', [function() {
+    angular.module('openfin.thumbnails', ['openfin.store'])
+        .controller('ThumbnailsCtrl', ['storeService', function(store) {
             var self = this;
+            var visitedNumber = 9;
 
-            self.stocks = [
-                'AAPL',
-                'MSFT',
-                'TITN',
-                'SNDK'
-            ];
+            self.stocks = store.getStocks().slice(0, visitedNumber);
 
-            self.open = function(stock) {
+            self.open = function(stockName) {
+                store.incrementStock(stockName);
                 var child = new fin.desktop.Window({
-                    name: stock + ' Stock Data',
+                    name: stockName + ' Stock Data',
                     url: 'd3fc-showcase.html'
                 }, function() {
                     child.show();


### PR DESCRIPTION
This is the first part, creating a first time list of visited stocks (yet to be decided), and incrementing how many times each has been clicked, to re-order them on reload. Also internally there's now a limit of thumbnails (set to 9).

This makes use of angular-storage.

The next part will be to add new stocks to the list, after #49.