### PR TITLE
Open showcase from search, save searched stocks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
     <script src="thumbnails-controller.js"></script>
     <script src="search-controller.js"></script>
     <script src="stock-controller.js"></script>
+    <script src="openfin-service.js"></script>
     <script src="store-service.js"></script>
     <script src="quandl-service.js"></script>
 </body>

--- a/public/openfin-service.js
+++ b/public/openfin-service.js
@@ -1,0 +1,22 @@
+(function() {
+    'use strict';
+
+    angular.module('openfin.openfin', ['openfin.store'])
+        .factory('openfinService', ['storeService', function(storeService) {
+            var self = this;
+
+            function open(title) {
+                storeService.incrementStock(title);
+                var child = new fin.desktop.Window({
+                    name: title + ' Stock Data',
+                    url: 'd3fc-showcase.html'
+                }, function() {
+                    child.show();
+                });
+            }
+
+            return {
+                open: open
+            };
+        }]);
+}());

--- a/public/stock-controller.js
+++ b/public/stock-controller.js
@@ -1,42 +1,47 @@
 (function() {
     'use strict';
 
-    angular.module('openfin.stock', ['openfin.quandl'])
-       .controller('StockCtrl', ['$routeParams', 'quandlService', function($routeParams, quandlService) {
-           var self = this;
-           self.stocks = [];
+    angular.module('openfin.stock', ['openfin.quandl', 'openfin.openfin'])
+       .controller('StockCtrl', ['$routeParams', 'quandlService', 'openfinService',
+           function($routeParams, quandlService, openfinService) {
+               var self = this;
+               self.stocks = [];
 
-           quandlService.stock().get({ query: $routeParams.query }, function(result) {
-               // Re-fetch the cached result.
-               var fetchedStocks = result.datasets,
-                   length = fetchedStocks.length,
-                   i,
-                   fetchedStock,
-                   stock;
+               quandlService.stock().get({ query: $routeParams.query }, function(result) {
+                   // Re-fetch the cached result.
+                   var fetchedStocks = result.datasets,
+                       length = fetchedStocks.length,
+                       i,
+                       fetchedStock,
+                       stock;
 
-               for (i = 0; i < length; i++) {
-                   fetchedStock = fetchedStocks[i];
-                   self.stocks.push({
-                       name: fetchedStock.name,
-                       code: fetchedStock.dataset_code
+                   for (i = 0; i < length; i++) {
+                       fetchedStock = fetchedStocks[i];
+                       self.stocks.push({
+                           name: fetchedStock.name,
+                           code: fetchedStock.dataset_code
+                       });
+                   }
+
+                   // After the stock meta-data has been fetched and displayed the financial data
+                   // can be retrieved and displayed
+                   for (i = 0; i < length; i++) {
+                       stock = self.stocks[i];
+                       fetchStockData(stock);
+                   }
+               });
+
+               function fetchStockData(stock) {
+                   quandlService.stockData().get({ code: stock.code }, function(result) {
+                       var data = result.stockData;
+                       stock.data = data.data;
+                       stock.startDate = data.startDate;
+                       stock.endDate = data.endDate;
                    });
                }
 
-               // After the stock meta-data has been fetched and displayed the financial data
-               // can be retrieved and displayed
-               for (i = 0; i < length; i++) {
-                   stock = self.stocks[i];
-                   fetchStockData(stock);
-               }
-           });
-
-           function fetchStockData(stock) {
-               quandlService.stockData().get({ code: stock.code }, function(result) {
-                   var data = result.stockData;
-                   stock.data = data.data;
-                   stock.startDate = data.startDate;
-                   stock.endDate = data.endDate;
-               });
-           }
-       }]);
+               self.open = function(stockName) {
+                   openfinService.open(stockName);
+               };
+           }]);
 }());

--- a/public/stockData.html
+++ b/public/stockData.html
@@ -1,7 +1,7 @@
 ﻿<div class="container-fluid">
     <ul>
         <li ng-repeat="stock in stockCtrl.stocks">
-            Name: {{stock.name}}, Code: {{stock.code}}, Start Date: {{stock.startDate}}, End Date: {{stock.endDate}}
+            Name: <a ng-click="stockCtrl.open(stock.code)">{{stock.name}}</a>, Code: {{stock.code}}, Start Date: {{stock.startDate}}, End Date: {{stock.endDate}}
             <ul>
                 <li ng-repeat="stockData in stock.data">
                     Date: {{stockData.date}}, Open: {{stockData.open}}

--- a/public/thumbnails-controller.js
+++ b/public/thumbnails-controller.js
@@ -1,21 +1,15 @@
 (function() {
     'use strict';
 
-    angular.module('openfin.thumbnails', ['openfin.store'])
-        .controller('ThumbnailsCtrl', ['storeService', function(store) {
+    angular.module('openfin.thumbnails', ['openfin.store', 'openfin.openfin'])
+        .controller('ThumbnailsCtrl', ['storeService', 'openfinService', function(storeService, openfinService) {
             var self = this;
             var visitedNumber = 9;
 
-            self.stocks = store.getStocks().slice(0, visitedNumber);
+            self.stocks = storeService.getStocks().slice(0, visitedNumber);
 
             self.open = function(stockName) {
-                store.incrementStock(stockName);
-                var child = new fin.desktop.Window({
-                    name: stockName + ' Stock Data',
-                    url: 'd3fc-showcase.html'
-                }, function() {
-                    child.show();
-                });
+                openfinService.open(stockName);
             };
         }]);
 }());

--- a/public/thumbnails.html
+++ b/public/thumbnails.html
@@ -1,7 +1,7 @@
 ﻿<div class="container-fluid">
     <div class="row">
         <div class="col-xs-4" ng-repeat="stock in thumbnailsCtrl.stocks">
-            <a class="thumbnail bg-primary" ng-click="thumbnailsCtrl.open(stock)" style="cursor: pointer">
+            <a class="thumbnail bg-primary" ng-click="thumbnailsCtrl.open(stock)">
                 <div style="color:black">
                     {{stock}}
                 </div>

--- a/src/assets/styles/style.less
+++ b/src/assets/styles/style.less
@@ -18,6 +18,10 @@ a.svg:after {
     margin: 0 auto;
 }
 
+a {
+    cursor: pointer;
+}
+
 a.svg {
     display: block;
     position: relative;


### PR DESCRIPTION
Allow showcase to be opened from search page. Store searched stocks locally and display as thumbnails.