### PR TITLE
Remove visual flicker when changing favourites

### DIFF
--- a/src/sidebars/favourites/favourites.js
+++ b/src/sidebars/favourites/favourites.js
@@ -4,6 +4,7 @@
     angular.module('openfin.favourites', ['openfin.store', 'openfin.quandl'])
         .controller('FavouritesCtrl', ['storeService', 'quandlService', '$timeout', function(storeService, quandlService, $timeout) {
             var self = this;
+            self.stocks = [];
 
             self.selection = '';
 
@@ -63,31 +64,51 @@
             };
 
             self.updateFavourites = function() {
-                self.stocks = [];
                 self.favourites = storeService.get();
+                var i,
+                    max,
+                    min;
+
+                // Remove the stocks no longer in the favourites
+                var removedStocksIndices = [];
+                for (i = 0, max = self.stocks.length; i < max; i++) {
+                    if (self.favourites.indexOf(self.stocks[i].code) === -1) {
+                        removedStocksIndices.push(i);
+                    }
+                }
+
+                // Remove from the end of the array to not change the indices
+                for (i = removedStocksIndices.length - 1, min = 0; i >= min; i--) {
+                    self.stocks.splice(removedStocksIndices[i], 1);
+                }
+
+                // Add new stocks from favourites
                 self.favourites.map(function(favourite) {
-                    quandlService.getData(favourite, function(stock) {
-                        var data = stock.data[0],
-                            price,
-                            delta,
-                            percentage;
+                    if (self.stocks.map(function(stock) { return stock.code; }).indexOf(favourite) === -1) {
+                        // This is a new stock
+                        quandlService.getData(favourite, function(stock) {
+                            var data = stock.data[0],
+                                price,
+                                delta,
+                                percentage;
 
-                        if (data) {
-                            price = data.close;
-                            delta = data.close - data.open;
-                            percentage = delta / data.open * 100;
+                            if (data) {
+                                price = data.close;
+                                delta = data.close - data.open;
+                                percentage = delta / data.open * 100;
 
-                            self.stocks.push({
-                                name: stock.name,
-                                code: stock.code,
-                                price: price,
-                                delta: delta,
-                                percentage: Math.abs(percentage),
-                                notification: false
-                            });
-                        }
-                    });
-                });
+                                self.stocks.push({
+                                    name: stock.name,
+                                    code: stock.code,
+                                    price: price,
+                                    delta: delta,
+                                    percentage: Math.abs(percentage),
+                                    notification: false
+                                });
+                            }
+                        });
+                    }
+                })
             };
 
             self.updateFavourites();


### PR DESCRIPTION
The problem was the stocks were being cleared, leading angular to not notice changes in the array as the DOM was reset. Probably.