### PR TITLE
Integrate d3fc-showcase as a module; remove iframe

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -152,6 +152,14 @@ module.exports = function(grunt) {
                 cwd: 'src/',
                 src: ['**/*.svg', '**/*.ico'],
                 dest: 'public'
+            },
+            fonts: {
+                files: [{
+                    expand: true,
+                    cwd: 'node_modules/d3fc-showcase/node_modules/bootstrap/dist/fonts/',
+                    src: ['**'],
+                    dest: 'public/assets/fonts'
+                }]
             }
         }
     });
@@ -173,7 +181,7 @@ module.exports = function(grunt) {
         var callback = this.async();
         grunt.util.spawn({
             grunt: true,
-            args: ['build'],
+            args: ['build:module'],
             opts: {
                 cwd: 'node_modules/d3fc-showcase/'
             }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "less": "^2.5.3"
   },
   "dependencies": {
-    "d3fc-showcase": "bjedrzejewski/d3fc-showcase#4f5daad"
+    "d3fc-showcase": "jleft/d3fc-showcase#openfin-integration"
   },
   "description": "Hosts the d3fc-showcase as an OpenFin application."
 }

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -4,6 +4,7 @@
         "moment":  true,
         "fin": true,
         "window": true,
-        "jQuery": true
+        "jQuery": true,
+        "sc": true
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -72,9 +72,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.8/angular-animate.js"></script>
     <script src="https://cdn.rawgit.com/auth0/angular-storage/master/dist/angular-storage.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3fc/5.1.0/d3fc.bundle.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha256-KXn5puMvxCw+dAYznun+drMdG1IFl3agK0p/pqT9KAo= sha512-2e8qq0ETcfWRI4HJBzQiA3UoyFk6tbNyG+qSaIBZLyW9Xf3sWZHN/lxe9fTh1U45DpPf07yj94KsUHHWe4Yk1A==" crossorigin="anonymous"></script>
     <script src="customScroller.js"></script>
     <script src="app.js"></script>
     <script src="main-controller.js"></script>
+    <script src="sc.js"></script>
     <script src="showcase/showcase-directive.js"></script>
     <script src="sidebars/sidebar-controller.js"></script>
     <script src="sidebars/favourites/favourites.js"></script>

--- a/src/showcase/showcase-directive.js
+++ b/src/showcase/showcase-directive.js
@@ -1,4 +1,4 @@
-(function() {
+(function(sc) {
     'use strict';
 
     angular.module('openfin.showcase', [])
@@ -8,7 +8,24 @@
                 templateUrl: 'showcase/showcase.html',
                 scope: {
                     selection: '='
+                },
+                link: function(scope, element) {
+                    var chart = sc.app(),
+                        firstRun = true;
+
+                    scope.$watch('selection', function(newSelection, previousSelection) {
+                        if (newSelection !== '') {
+                            if (firstRun) {
+                                firstRun = false;
+                                chart.run(element[0].children[0]);
+                            }
+
+                            if (newSelection !== previousSelection) {
+                                chart.changeQuandlProduct(newSelection);
+                            }
+                        }
+                    });
                 }
-            }
+            };
         }]);
-}());
+}(sc));

--- a/src/showcase/showcase.html
+++ b/src/showcase/showcase.html
@@ -1,2 +1,1 @@
-<iframe class="full-content"
-        src="{{selection !== '' ? 'd3fc-showcase.html?stockcode=' + selection : ''}}"></iframe>
+<div id="showcase-container" class="full-content" selection="selection"></div>


### PR DESCRIPTION
This is still a bit rough, but I thought it was worth sharing. Hopefully this is heading in the right direction!

It's using the [jleft/d3fc-showcase#openfin-integration/](https://github.com/jleft/d3fc-showcase/tree/openfin-integration)

The showcase can now be exported as a module, using `grunt:module` with a _very_ simple API

```js
// Create a instance of the showcase app
var chart = showcase.app();

// Renders the app into the specified element
chart.run(element);

// Given a string of a Quandl product, this will change the product which the chart is displaying
chart.changeQuandlProduct(productString);

// Thinking of removing this - it allows the callback to manipulate the model
// very flexible, but (hopefully) YAGNI
chart.updateModel(callback);
```