### PR TITLE
Disable selection (closes #177)

### DIFF
--- a/src/assets/styles/style.less
+++ b/src/assets/styles/style.less
@@ -10,6 +10,10 @@
 @import "showcase-changes.less";
 @import "custom-scroll.less";
 
+body {
+  -webkit-user-select: none;
+}
+
 .row {
   margin: 0px;
 }


### PR DESCRIPTION
Disables selection across the whole app. I don't think it makes sense anywhere to have anything selected?