### PR TITLE
Default and minimum sizing

### DIFF
--- a/src/app.json
+++ b/src/app.json
@@ -5,7 +5,11 @@
         "url": "http://owennw.github.io/OpenFinD3FC/index.html",
         "uuid": "OpenFinD3FC",
         "applicationIcon": "http://owennw.github.io/OpenFinD3FC/favicon.ico",
-        "autoShow": true
+        "autoShow": true,
+        "minWidth": 844,
+        "minHeight": 475,
+        "defaultWidth": 1280,
+        "defaultHeight": 720 
     },
     "runtime": {
         "arguments": "",


### PR DESCRIPTION
The minimum size leaves a 20px padding on the left of the logo, as it is on the right. The ratios for the minimum and default are 16:9.