### PR TITLE
Don't select favourite/search card when toggling icon

### DIFF
--- a/src/sidebars/star.html
+++ b/src/sidebars/star.html
@@ -1,1 +1,1 @@
-﻿<div class="glyphicon glyphicon-star {{starClasses(stock)}}" ng-click="starClick(stock)"></div>
+﻿<div class="glyphicon glyphicon-star {{starClasses(stock)}}" ng-click="starClick(stock); $event.stopPropagation();"></div>


### PR DESCRIPTION
The bug was also present on the search cards. Thanks to good design ( ;-) ) it's now fixed in both!