### PR TITLE
Restore top splitter on search tab

### DIFF
--- a/src/sidebars/search/search.less
+++ b/src/sidebars/search/search.less
@@ -24,7 +24,7 @@
     padding-left: 12px;
   }
 
-  search:first-of-type {
+  .sidetab > div:first-of-type search .search-result {
     border-top: @search-splitter-style;
   }
 


### PR DESCRIPTION
Looks a bit overkill but I removed bits at a time and it wouldn't work properly.