### PR TITLE
Update showcase integration

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -141,6 +141,7 @@ module.exports = function(grunt) {
                     'angular-animate/angular-animate.min.js',
                     'angular-storage/dist/angular-storage.min.js',
                     'd3fc/dist/d3fc.bundle.min.js',
+                    'd3fc-showcase/node_modules/bootstrap/js/dropdown.js',
                     'malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.js'
                 ],
                 dest: 'public/assets/js/',

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "angular-animate": "^1.4.8",
     "angular-resource": "^1.4.8",
     "angular-storage": "0.0.13",
-    "d3fc": "^5.1.0",
-    "d3fc-showcase": "jleft/d3fc-showcase#openfin-integration",
+    "d3fc": "^5.2.0",
+    "d3fc-showcase": "ScottLogic/d3fc-showcase#2a659f6ae092c8cff85cfd956d271eb4f4e894c1",
     "jquery": "^1.11.1",
     "malihu-custom-scrollbar-plugin": "^3.1.3",
     "moment": "^2.10.6"

--- a/src/index.html
+++ b/src/index.html
@@ -79,6 +79,7 @@
     <script src="assets/js/angular-animate.min.js"></script>
     <script src="assets/js/angular-storage.min.js"></script>
     <script src="assets/js/d3fc.bundle.min.js"></script>
+    <script src="assets/js/dropdown.js"></script>
     <script src="customScroller.js"></script>
     <script src="app.js"></script>
     <script src="sc.js"></script>

--- a/src/showcase/showcase-directive.js
+++ b/src/showcase/showcase-directive.js
@@ -10,7 +10,7 @@
                     selection: '&'
                 },
                 link: function(scope, element) {
-                    var chart = sc.app(),
+                    var chart = sc.app().quandlApiKey('kM9Z9aEULVDD7svZ4A8B'),
                         firstRun = true;
 
                     scope.$watch('selection()', function(newSelection, previousSelection) {


### PR DESCRIPTION
This updates integration of d3fc-showcase as a module, now that it has landed in the main repo: https://github.com/ScottLogic/d3fc-showcase/pull/537

Changes in d3fc-showcase:
- Bug fixes (see [the commit history](https://github.com/ScottLogic/d3fc-showcase/commits/2a659f6ae092c8cff85cfd956d271eb4f4e894c1) for more info)
- No longer fetch Coinbase products by default
- Navigator extent gradient! :rainbow: (May need to override some of our Less variables to get the correct colours)
- Fixes the indicator close label positioning (thanks for raising the issue :smiley:)
- Added a method to the showcase API to set the Quandl API key (#193)

Proposed changes to OpenFinD3FC (in this PR):
- Rather than using my branch, the dependency is linked to commit in the showcase's `develop` branch. When the next release lands, I'd suggest that this dependency is updated to the release.
- Updated d3fc from 5.1.0 -> [5.2.0](https://github.com/ScottLogic/d3fc/releases/tag/v5.2.0) (the showcase needs this version)
- Showcase depends on Bootstrap's dropdown JS, so I've added this back in (it's used for the series and indicator dropdowns)
- Set Quandl API key for the showcase through its API


Let me know what you think.

If you think anything is missing or needs to be changed, just let me know and I'll see what we can do.