### PR TITLE
Update navigator to have a darker bg area and lighter brush

### DIFF
--- a/src/showcase/showcase-changes.less
+++ b/src/showcase/showcase-changes.less
@@ -13,7 +13,7 @@
 @bollinger-fill-colour: fade(@chart-fade, 20%);
 @bollinger-average-colour: @tertiary-yellow;
 
-@faded-colour: darken(@chart-fade, 92%);
+@faded-colour: fade(@chart-fade, 0%);
 
 @navigator-extent-colour-top: @secondary-orange;
 @navigator-extent-colour-bottom: @faded-colour;
@@ -69,7 +69,8 @@
   #navbar-container .plot-area {
     .multi {
       .area {
-        fill: @chart-fade !important;
+        fill: url(#brush-gradient) !important;
+        fill-opacity: 20%;
       }
 
       path {


### PR DESCRIPTION
Uses a faded version of the brush's linear gradient. Only issue is that the opacity is 20% rather than 50, as 50% was too bright (this is an issue with the showcase, which I've raised)