### PR TITLE
Disallow tearout of single favourite

### DIFF
--- a/src/sidebars/favourites/favourite-controller.js
+++ b/src/sidebars/favourites/favourite-controller.js
@@ -32,6 +32,10 @@
             this.selectionService.select(stock);
         }
 
+        single(stock) {
+            return this.stocks.length === 1 ? 'single' : '';
+        }
+
         update() {
             this.currentWindowService.ready(() => {
                 if (!this.store) {

--- a/src/sidebars/favourites/favourite-controller.js
+++ b/src/sidebars/favourites/favourite-controller.js
@@ -32,7 +32,7 @@
             this.selectionService.select(stock);
         }
 
-        single(stock) {
+        single() {
             return this.stocks.length === 1 ? 'single' : '';
         }
 

--- a/src/sidebars/favourites/favourite-directive.js
+++ b/src/sidebars/favourites/favourite-directive.js
@@ -11,7 +11,8 @@
                     selection: '&',
                     select: '&',
                     icon: '&',
-                    renderChart: '&'
+                    renderChart: '&',
+                    single: '&'
                 }
             };
         }]);

--- a/src/sidebars/favourites/favourite.html
+++ b/src/sidebars/favourites/favourite.html
@@ -2,7 +2,7 @@
     <div class="favourite darkens{{selection() !== stock.code ? '' : ' dark'}}" ng-click="select(stock)" draggable="false"
          ng-init="(selection() == null || selection() === '') && select(stock);">
         <div class="top">
-            <img class="tearable" src="assets/svg/drag_handle.svg" />
+            <img class="tearable {{single(stock)}}" src="assets/svg/drag_handle.svg" />
             <div class="star" ng-controller="StarCtrl as starCtrl">
                 <star ng-init="starCtrl.check = true" favourite-url="starCtrl.favouriteUrl(stock)" star-click="starCtrl.click(stock)"></star>
             </div>

--- a/src/sidebars/favourites/favourite.html
+++ b/src/sidebars/favourites/favourite.html
@@ -2,7 +2,7 @@
     <div class="favourite darkens{{selection() !== stock.code ? '' : ' dark'}}" ng-click="select(stock)" draggable="false"
          ng-init="(selection() == null || selection() === '') && select(stock);">
         <div class="top">
-            <img class="tearable {{single(stock)}}" src="assets/svg/drag_handle.svg" />
+            <img class="tearable {{single()}}" src="assets/svg/drag_handle.svg" />
             <div class="star" ng-controller="StarCtrl as starCtrl">
                 <star ng-init="starCtrl.check = true" favourite-url="starCtrl.favouriteUrl(stock)" star-click="starCtrl.click(stock)"></star>
             </div>

--- a/src/sidebars/favourites/favourites.less
+++ b/src/sidebars/favourites/favourites.less
@@ -51,6 +51,10 @@
     cursor: move;
   }
 
+  .single {
+    cursor: default;
+  }
+
   .name {
     font-size: 12px;
     font-weight: @font-thin;

--- a/src/sidebars/favourites/tearout.js
+++ b/src/sidebars/favourites/tearout.js
@@ -167,6 +167,11 @@
                                     return false;
                                 }
 
+                                if (dragElement.classList.contains('single')) {
+                                    // There is only one favourite card so don't allow tearing out
+                                    return false;
+                                }
+
                                 me.setCurrentlyDragging(true)
                                     .setOffset(e.offsetX, e.offsetY)
                                     .moveTearoutWindow(e.screenX, e.screenY)

--- a/src/sidebars/sidebar.html
+++ b/src/sidebars/sidebar.html
@@ -5,7 +5,7 @@
         </div>
         <div id="favScroll" class="sideScroll">
             <div class="sidetab" ng-repeat="stock in favouritesCtrl.stocks | orderBy: 'index'" ng-show="sidebarCtrl.showFavourites()">
-                <favourite selection="favouritesCtrl.selection()" select="favouritesCtrl.select(stock)"
+                <favourite selection="favouritesCtrl.selection()" select="favouritesCtrl.select(stock)" single="favouritesCtrl.single(stock)"
                            stock="stock" icon="favouritesCtrl.icon(stock)" render-chart="favouritesCtrl.renderChart(stock)">
                 </favourite>
             </div>

--- a/src/sidebars/sidebar.html
+++ b/src/sidebars/sidebar.html
@@ -5,7 +5,7 @@
         </div>
         <div id="favScroll" class="sideScroll">
             <div class="sidetab" ng-repeat="stock in favouritesCtrl.stocks | orderBy: 'index'" ng-show="sidebarCtrl.showFavourites()">
-                <favourite selection="favouritesCtrl.selection()" select="favouritesCtrl.select(stock)" single="favouritesCtrl.single(stock)"
+                <favourite selection="favouritesCtrl.selection()" select="favouritesCtrl.select(stock)" single="favouritesCtrl.single()"
                            stock="stock" icon="favouritesCtrl.icon(stock)" render-chart="favouritesCtrl.renderChart(stock)">
                 </favourite>
             </div>


### PR DESCRIPTION
Chose to remove tearing out from the tearout file itself, on mouse down. That way the tearout window won't be destroyed/recreated, which would introduce additional overhead to changing the number of favourites from 1 to 2 or vice versa.